### PR TITLE
fix: hydration error on next.js

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -72,7 +72,7 @@ export const Navbar = () => {
                   className="flex md:hidden h-5 w-5"
                   onClick={() => setIsOpen(true)}
                 >
-                  <span className="sr-only">Menu Icon</span>
+                  <text className="sr-only">Menu Icon</text>
                 </Menu>
               </SheetTrigger>
 


### PR DESCRIPTION
i rewriting code frin React to Next.js, and i had an error:
```
Error: Hydration failed because the initial UI does not match what was rendered on the server.
See more info here: https://nextjs.org/docs/messages/react-hydration-error

Expected server HTML to contain a matching <span> in <svg>.


...
  <_c>
    <svg>
    ^^^^^
      <span>
```
after span -> text - error doesnt occure